### PR TITLE
Add mutable implementations

### DIFF
--- a/emerge.mjs
+++ b/emerge.mjs
@@ -45,385 +45,558 @@ Add benchmarks with large real-world data.
 */
 
 // Minifiable aliases
-const Object_ = Object
-const Array_  = Array
-const NOP     = Object.prototype
+const Object_ = Object;
+const Array_ = Array;
+const NOP = Object.prototype;
 
 /* Bool */
 
 export function is(one, other) {
-  return one === other || (isNaN(one) && isNaN(other))
+  return one === other || (isNaN(one) && isNaN(other));
 }
 
 export function equal(one, other) {
-  return equalBy(other, one, equal)
+  return equalBy(other, one, equal);
 }
 
 export function equalBy(one, other, fun) {
-  validate(fun, isFunction)
-  return is(one, other) || (
-    isArray(one)
-    ? isArray(other) && everyListPairBy(one, other, fun)
-    : isDict(one)
-    ? isDict(other) && everyDictPairBy(one, other, fun)
-    : false
-  )
+  validate(fun, isFunction);
+  return (
+    is(one, other) ||
+    (isArray(one)
+      ? isArray(other) && everyListPairBy(one, other, fun)
+      : isDict(one)
+      ? isDict(other) && everyDictPairBy(one, other, fun)
+      : false)
+  );
 }
 
 /* Get */
 
 export function get(value, key) {
-  return isNil(value) ? undefined : value[key]
+  return isNil(value) ? undefined : value[key];
 }
 
 export function getIn(value, path) {
-  validate(path, isArray)
-  return fold(path, value, get)
+  validate(path, isArray);
+  return fold(path, value, get);
 }
 
-export function scan() {
-  return fold1(arguments, get)
+export function scan(...args) {
+  return fold1(args, get);
 }
 
 /* Update */
 
 export function put(prev, key, value) {
-  validateKey(key)
-  return assoc(prev, key, putAny(get(prev, key), value))
+  validateKey(key);
+  return assoc(prev, key, putAny(get(prev, key), value));
+}
+
+export function putMut(prev, key, value) {
+  validateKey(key);
+  return assocMut(prev, key, putAnyMut(get(prev, key), value));
 }
 
 export function putIn(prev, path, next) {
-  validatePath(path)
-  return assocIn(prev, path, putAny(getIn(prev, path), next))
+  validatePath(path);
+  return assocIn(prev, path, putAny(getIn(prev, path), next));
+}
+
+export function putInMut(prev, path, next) {
+  validatePath(path);
+  return assocInMut(prev, path, putAnyMut(getIn(prev, path), next));
 }
 
 export function putBy(prev, key, fun, ...rest) {
-  validate(fun, isFunction)
-  return put(prev, key, fun(get(prev, key), ...rest))
+  validate(fun, isFunction);
+  return put(prev, key, fun(get(prev, key), ...rest));
+}
+
+export function putByMut(prev, key, fun, ...rest) {
+  validate(fun, isFunction);
+  return putMut(prev, key, fun(get(prev, key), ...rest));
 }
 
 export function putInBy(prev, path, fun, ...rest) {
-  validate(fun, isFunction)
-  return putIn(prev, path, fun(getIn(prev, path), ...rest))
+  validate(fun, isFunction);
+  return putIn(prev, path, fun(getIn(prev, path), ...rest));
 }
 
-export function patch(prev, next) {
-  if (arguments.length > 2) return fold1(arguments, patchTwo)
-  return patchTwo(prev, next)
+export function putInByMut(prev, path, fun, ...rest) {
+  validate(fun, isFunction);
+  return putInMut(prev, path, fun(getIn(prev, path), ...rest));
 }
 
-export function merge(prev, next) {
-  if (arguments.length > 2) return fold1(arguments, mergeTwo)
-  return mergeTwo(prev, next)
+export function patch(...args) {
+  if (args.length > 2) return fold1(args, patchTwo);
+  return patchTwo(...args);
+}
+
+export function patchMut(...args) {
+  if (args.length > 2) return fold1(args, patchTwoMut);
+  return patchTwoMut(...args);
+}
+
+export function merge(...args) {
+  if (args.length > 2) return fold1(args, mergeTwo);
+  return mergeTwo(...args);
+}
+
+export function mergeMut(...args) {
+  if (args.length > 2) return fold1(args, mergeTwoMut);
+  return mergeTwoMut(...args);
 }
 
 export function insert(list, index, value) {
-  list = onlyArray(list)
-  validateBounds(list, index)
-  list = list.slice()
-  list.splice(index, 0, value)
-  return list
+  list = onlyArray(list);
+  validateBounds(list, index);
+  list = list.slice();
+  list.splice(index, 0, value);
+  return list;
+}
+
+export function insertMut(list, index, value) {
+  list = onlyArray(list);
+  validateBounds(list, index);
+  list.splice(index, 0, value);
+  return list;
 }
 
 export function remove(value, key) {
   if (isArray(value)) {
-    validate(key, isInteger)
-    return listRemove(value, key)
+    validate(key, isInteger);
+    return listRemove(value, key);
   }
-  validateKey(key)
-  return dictRemove(onlyDict(value), key)
+  validateKey(key);
+  return dictRemove(onlyDict(value), key);
+}
+
+export function removeMut(value, key) {
+  if (isArray(value)) {
+    validate(key, isInteger);
+    return listRemoveMut(value, key);
+  }
+  validateKey(key);
+  return dictRemoveMut(onlyDict(value), key);
 }
 
 // Too much logic, support code, and overhead. TODO simplify.
 export function removeIn(value, path) {
-  validatePath(path)
-  if (!path.length) return undefined
+  validatePath(path);
+  if (!path.length) return undefined;
 
-  value = onlyData(value)
-  if (!hasIn(value, path)) return value
+  value = onlyData(value);
+  if (!hasIn(value, path)) return value;
 
-  const prefix = init(path)
-  return assocIn(value, prefix, remove(getIn(value, prefix), last(path)))
+  const prefix = init(path);
+  return assocIn(value, prefix, remove(getIn(value, prefix), last(path)));
+}
+
+export function removeInMut(value, path) {
+  validatePath(path);
+  if (!path.length) return undefined;
+
+  value = onlyData(value);
+  if (!hasIn(value, path)) return value;
+
+  const prefix = init(path);
+  return assocInMut(value, prefix, removeMut(getIn(value, prefix), last(path)));
 }
 
 /* Update (internal) */
 
 function putAny(prev, next) {
-  return (
-    is(prev, next)
+  return is(prev, next)
     ? prev
     : isArray(prev)
-    ? (isArray(next) ? listReplaceBy(prev, next, putAny) : next)
+    ? isArray(next)
+      ? listReplaceBy(prev, next, putAny)
+      : next
     : isDict(prev)
-    ? (isDict(next) ? dictReplaceBy(prev, next, putAny) : next)
-    : next
-  )
+    ? isDict(next)
+      ? dictReplaceBy(prev, next, putAny)
+      : next
+    : next;
+}
+
+function putAnyMut(prev, next) {
+  return is(prev, next)
+    ? prev
+    : isArray(prev)
+    ? isArray(next)
+      ? listReplaceByMut(prev, next, putAnyMut)
+      : next
+    : isDict(prev)
+    ? isDict(next)
+      ? dictReplaceByMut(prev, next, putAnyMut)
+      : next
+    : next;
 }
 
 function patchTwo(prev, next) {
-  prev = onlyDict(prev)
-  next = onlyDict(next)
-  if (is(prev, next)) return prev
-  return patchBy(prev, next, putAny)
+  prev = onlyDict(prev);
+  next = onlyDict(next);
+  if (is(prev, next)) return prev;
+  return patchBy(prev, next, putAny);
+}
+
+function patchTwoMut(prev, next) {
+  prev = onlyDict(prev);
+  next = onlyDict(next);
+  if (is(prev, next)) return prev;
+  return patchByMut(prev, next, putAnyMut);
 }
 
 function mergeTwo(prev, next) {
-  return mergeTwoAny(onlyDict(prev), onlyDict(next))
+  return mergeTwoAny(onlyDict(prev), onlyDict(next));
+}
+
+function mergeTwoMut(prev, next) {
+  return mergeTwoAnyMut(onlyDict(prev), onlyDict(next));
 }
 
 // Unlike `mergeTwo`, doesn't require operands to be dicts; replaces non-dicts.
 function mergeTwoAny(prev, next) {
-  if (is(prev, next)) return prev
-  return patchBy(toDict(prev), toDict(next), mergeOrPut)
+  if (is(prev, next)) return prev;
+  return patchBy(toDict(prev), toDict(next), mergeOrPut);
+}
+
+function mergeTwoAnyMut(prev, next) {
+  if (is(prev, next)) return prev;
+  return patchByMut(toDict(prev), toDict(next), mergeOrPutMut);
 }
 
 function mergeOrPut(prev, next) {
-  return isDict(next) ? mergeTwoAny(prev, next) : putAny(prev, next)
+  return isDict(next) ? mergeTwoAny(prev, next) : putAny(prev, next);
+}
+
+function mergeOrPutMut(prev, next) {
+  return isDict(next) ? mergeTwoAnyMut(prev, next) : putAnyMut(prev, next);
 }
 
 function assoc(prev, key, next) {
-  if (isArray(prev)) return listPut(prev, key, next)
-  return dictPut(onlyDict(prev), key, next)
+  if (isArray(prev)) return listPut(prev, key, next);
+  return dictPut(onlyDict(prev), key, next);
+}
+
+function assocMut(prev, key, next) {
+  if (isArray(prev)) return listPutMut(prev, key, next);
+  return dictPutMut(onlyDict(prev), key, next);
 }
 
 function assocIn(prev, path, next) {
-  return path.length ? assocInAt(prev, path, next, 0) : next
+  return path.length ? assocInAt(prev, path, next, 0) : next;
+}
+
+function assocInMut(prev, path, next) {
+  return path.length ? assocInAtMut(prev, path, next, 0) : next;
 }
 
 function assocInAt(prev, path, next, index) {
-  const key = path[index]
+  const key = path[index];
   return index < path.length - 1
     ? assoc(prev, key, assocInAt(get(prev, key), path, next, index + 1))
-    : assoc(prev, key, next)
+    : assoc(prev, key, next);
+}
+
+function assocInAtMut(prev, path, next, index) {
+  const key = path[index];
+  return index < path.length - 1
+    ? assocMut(prev, key, assocInAtMut(get(prev, key), path, next, index + 1))
+    : assocMut(prev, key, next);
 }
 
 function listPut(list, index, value) {
-  validateBounds(list, index)
-  if (index < list.length && is(list[index], value)) return list
-  const out = list.slice()
-  out[index] = value
-  return out
+  validateBounds(list, index);
+  if (index < list.length && is(list[index], value)) return list;
+  const out = list.slice();
+  out[index] = value;
+  return out;
+}
+
+function listPutMut(list, index, value) {
+  validateBounds(list, index);
+  if (index < list.length && is(list[index], value)) return list;
+  list[index] = value;
+  return list;
 }
 
 function dictPut(dict, key, value) {
-  key = String(key)
-  if (has(dict, key) && is(dict[key], value)) return dict
-  const out = {}
-  assign(out, dict)
-  out[key] = value
-  return out
+  key = String(key);
+  if (has(dict, key) && is(dict[key], value)) return dict;
+  const out = {};
+  assign(out, dict);
+  out[key] = value;
+  return out;
+}
+
+function dictPutMut(dict, key, value) {
+  key = String(key);
+  if (has(dict, key) && is(dict[key], value)) return dict;
+  dict[key] = value;
+  return dict;
 }
 
 function listRemove(list, index) {
   if (isNatural(index) && index < list.length) {
-    list = list.slice()
-    list.splice(index, 1)
+    list = list.slice();
+    list.splice(index, 1);
   }
-  return list
+  return list;
+}
+
+function listRemoveMut(list, index) {
+  if (isNatural(index) && index < list.length) {
+    list.splice(index, 1);
+  }
+  return list;
 }
 
 function dictRemove(dict, key) {
-  key = String(key)
-  if (!has(dict, key)) return dict
-  const out = {}
+  key = String(key);
+  if (!has(dict, key)) return dict;
+  const out = {};
   for (const dkey in dict) {
-    if (dkey === key) continue
-    out[dkey] = dict[dkey]
+    if (dkey === key) continue;
+    out[dkey] = dict[dkey];
   }
-  return equalBy(dict, out, is) ? dict : out
+  return equalBy(dict, out, is) ? dict : out;
+}
+
+function dictRemoveMut(dict, key) {
+  key = String(key);
+  if (!has(dict, key)) return dict;
+  delete dict[key];
+  return dict;
 }
 
 function listReplaceBy(prev, next, fun) {
-  const out = Array_(next.length)
-  for (let i = 0; i < next.length; i += 1) out[i] = fun(prev[i], next[i])
-  return equalBy(prev, out, is) ? prev : out
+  const out = Array_(next.length);
+  for (let i = 0; i < next.length; i += 1) out[i] = fun(prev[i], next[i]);
+  return equalBy(prev, out, is) ? prev : out;
+}
+
+function listReplaceByMut(prev, next, fun) {
+  for (let i = 0; i < next.length; i += 1) {
+    assignIfChanged(prev, i, fun(prev[i], next[i]));
+  }
+  if (next.length < prev.length) {
+    prev.splice(next.length, prev.length - next.length);
+  }
+  return prev;
 }
 
 function dictReplaceBy(prev, next, fun) {
-  const out = {}
-  for (const key in next) out[key] = fun(prev[key], next[key])
-  return equalBy(prev, out, is) ? prev : out
+  const out = {};
+  for (const key in next) out[key] = fun(prev[key], next[key]);
+  return equalBy(prev, out, is) ? prev : out;
+}
+
+function dictReplaceByMut(prev, next, fun) {
+  for (const key in next) {
+    assignIfChanged(prev, key, fun(prev[key], next[key]));
+  }
+  for (const key in prev) if (!has(next, key)) delete prev[key];
+  return prev;
 }
 
 function patchBy(prev, next, fun) {
-  const out = {}
-  assign(out, prev)
-  for (const key in next) out[key] = fun(prev[key], next[key])
-  return equalBy(prev, out, is) ? prev : out
+  const out = {};
+  assign(out, prev);
+  for (const key in next) out[key] = fun(prev[key], next[key]);
+  return equalBy(prev, out, is) ? prev : out;
+}
+
+function patchByMut(prev, next, fun) {
+  for (const key in next) {
+    assignIfChanged(prev, key, fun(prev[key], next[key]));
+  }
+  return prev;
 }
 
 /* Utils */
 
+// Avoid reassignment of same value, for immer's sake
+function assignIfChanged(prev, key, nextVal) {
+  if (!is(prev[key], nextVal)) {
+    prev[key] = nextVal;
+  }
+  return prev;
+}
+
 function validatePath(value) {
-  validate(value, isArray)
-  value.forEach(validateKey)
+  validate(value, isArray);
+  value.forEach(validateKey);
 }
 
 function validateKey(value) {
   // The readme explains why we do this.
-  if (isSymbol(value)) throw Error(`unexpected symbol key ${show(value)}`)
-  validate(value, isViableAsKey)
+  if (isSymbol(value)) throw Error(`unexpected symbol key ${show(value)}`);
+  validate(value, isViableAsKey);
 }
 
 // Note that when accessing a dict property, a number is converted to a string.
 function isViableAsKey(value) {
-  return isString(value) || isFinite(value)
+  return isString(value) || isFinite(value);
 }
 
 function isNumber(value) {
-  return typeof value === 'number'
+  return typeof value === "number";
 }
 
 function isFinite(value) {
-  return isNumber(value) && !isNaN(value) && !isInfinity(value)
+  return isNumber(value) && !isNaN(value) && !isInfinity(value);
 }
 
 function isNaN(value) {
-  return value !== value  // eslint-disable-line no-self-compare
+  return value !== value; // eslint-disable-line no-self-compare
 }
 
 function isInfinity(value) {
-  return value === Infinity || value === -Infinity
+  return value === Infinity || value === -Infinity;
 }
 
 function isObject(value) {
-  return value !== null && typeof value === 'object'
+  return value !== null && typeof value === "object";
 }
 
 function isDict(value) {
-  if (!isObject(value)) return false
-  const proto = Object_.getPrototypeOf(value)
-  return proto === null || proto === NOP
+  if (!isObject(value)) return false;
+  const proto = Object_.getPrototypeOf(value);
+  return proto === null || proto === NOP;
 }
 
 function isArray(value) {
-  return isObject(value) && value instanceof Array_
+  return isObject(value) && value instanceof Array_;
 }
 
 function isFunction(value) {
-  return typeof value === 'function'
+  return typeof value === "function";
 }
 
 function isInteger(value) {
-  return typeof value === 'number' && (value % 1) === 0
+  return typeof value === "number" && value % 1 === 0;
 }
 
 function isNatural(value) {
-  return isInteger(value) && value >= 0
+  return isInteger(value) && value >= 0;
 }
 
 function isString(value) {
-  return typeof value === 'string'
+  return typeof value === "string";
 }
 
 function isSymbol(value) {
-  return typeof value === 'symbol'
+  return typeof value === "symbol";
 }
 
 function everyListPairBy(one, other, fun) {
-  if (one.length !== other.length) return false
+  if (one.length !== other.length) return false;
   for (let i = 0; i < one.length; i += 1) {
-    if (!fun(one[i], other[i])) return false
+    if (!fun(one[i], other[i])) return false;
   }
-  return true
+  return true;
 }
 
 function everyDictPairBy(one, other, fun) {
   // Breadth-first: compare key sets.
-  for (const key in one)   if (!has(other, key)) return false
-  for (const key in other) if (!has(one, key))   return false
+  for (const key in one) if (!has(other, key)) return false;
+  for (const key in other) if (!has(one, key)) return false;
 
   // Now a depth-first comparison.
-  for (const key in one) if (!fun(one[key], other[key])) return false
-  return true
+  for (const key in one) if (!fun(one[key], other[key])) return false;
+  return true;
 }
 
-function fold(list, acc, fun, a, b, c, d, e) {
+function fold(list, acc, fun, ...rest) {
   for (let i = 0; i < list.length; i += 1) {
-    acc = fun(acc, list[i], i, a, b, c, d, e)
+    acc = fun(acc, list[i], i, ...rest);
   }
-  return acc
+  return acc;
 }
 
-function fold1(list, fun, a, b, c, d, e) {
-  let acc = list[0]
+function fold1(list, fun, ...rest) {
+  let [acc] = list;
   for (let i = 1; i < list.length; i += 1) {
-    acc = fun(acc, list[i], i, a, b, c, d, e)
+    acc = fun(acc, list[i], i, ...rest);
   }
-  return acc
+  return acc;
 }
 
 // Requires extreme care: when calling this on a dict, a numeric key must be
 // converted to a string first.
 function has(value, key) {
-  return isObject(value) && NOP.hasOwnProperty.call(value, key)
+  return isObject(value) && NOP.hasOwnProperty.call(value, key);
 }
 
 // Suspicious. Would prefer to get rid of this.
 function hasIn(value, path) {
-  return fold(path, value, getOrMissing) !== missing
+  return fold(path, value, getOrMissing) !== missing;
 }
 
-const missing = Symbol()
+const missing = Symbol("missing");
 
 function getOrMissing(value, key) {
-  key = String(key)
-  return has(value, key) ? value[key] : missing
+  key = String(key);
+  return has(value, key) ? value[key] : missing;
 }
 
 function assign(out, src) {
-  for (const key in src) out[key] = src[key]
+  for (const key in src) out[key] = src[key];
 }
 
 function onlyData(value) {
-  return isArray(value) ? value : onlyDict(value)
+  return isArray(value) ? value : onlyDict(value);
 }
 
 function onlyArray(value) {
-  if (isNil(value)) return []
-  validate(value, isArray)
-  return value
+  if (isNil(value)) return [];
+  validate(value, isArray);
+  return value;
 }
 
 function onlyDict(value) {
-  if (isNil(value)) return {}
-  validate(value, isDict)
-  return value
+  if (isNil(value)) return {};
+  validate(value, isDict);
+  return value;
 }
 
 function toDict(value) {
-  return isDict(value) ? value : {}
+  return isDict(value) ? value : {};
 }
 
 function isNil(value) {
-  return value == null
+  return value == null;
 }
 
 function init(list) {
-  return list.slice(0, list.length - 1)
+  return list.slice(0, list.length - 1);
 }
 
 function last(list) {
-  return list[list.length - 1]
+  return list[list.length - 1];
 }
 
 function validateBounds(list, index) {
-  validate(index, isNatural)
+  validate(index, isNatural);
   if (!(index <= list.length)) {
-    throw Error(`index ${index} out of bounds for length ${list.length}`)
+    throw Error(`index ${index} out of bounds for length ${list.length}`);
   }
 }
 
 function validate(value, test) {
-  if (!test(value)) throw Error(`expected ${show(value)} to satisfy test ${show(test)}`)
+  if (!test(value)) {
+    throw Error(`expected ${show(value)} to satisfy test ${show(test)}`);
+  }
 }
 
 function show(value) {
   return isFunction(value)
-    ? (value.name || value.toString())
+    ? value.name || value.toString()
     : isArray(value) || isDict(value)
     ? JSON.stringify(value)
     : isString(value)
     ? `"${value}"`
-    : String(value)
+    : String(value);
 }

--- a/emerge.mjs
+++ b/emerge.mjs
@@ -45,22 +45,22 @@ Add benchmarks with large real-world data.
 */
 
 // Minifiable aliases
-const Object_ = Object;
-const Array_ = Array;
-const NOP = Object.prototype;
+const Object_ = Object
+const Array_ = Array
+const NOP = Object.prototype
 
 /* Bool */
 
 export function is(one, other) {
-  return one === other || (isNaN(one) && isNaN(other));
+  return one === other || (isNaN(one) && isNaN(other))
 }
 
 export function equal(one, other) {
-  return equalBy(other, one, equal);
+  return equalBy(other, one, equal)
 }
 
 export function equalBy(one, other, fun) {
-  validate(fun, isFunction);
+  validate(fun, isFunction)
   return (
     is(one, other) ||
     (isArray(one)
@@ -68,140 +68,140 @@ export function equalBy(one, other, fun) {
       : isDict(one)
       ? isDict(other) && everyDictPairBy(one, other, fun)
       : false)
-  );
+  )
 }
 
 /* Get */
 
 export function get(value, key) {
-  return isNil(value) ? undefined : value[key];
+  return isNil(value) ? undefined : value[key]
 }
 
 export function getIn(value, path) {
-  validate(path, isArray);
-  return fold(path, value, get);
+  validate(path, isArray)
+  return fold(path, value, get)
 }
 
 export function scan(...args) {
-  return fold1(args, get);
+  return fold1(args, get)
 }
 
 /* Update */
 
 export function put(prev, key, value) {
-  validateKey(key);
-  return assoc(prev, key, putAny(get(prev, key), value));
+  validateKey(key)
+  return assoc(prev, key, putAny(get(prev, key), value))
 }
 
 export function putMut(prev, key, value) {
-  validateKey(key);
-  return assocMut(prev, key, putAnyMut(get(prev, key), value));
+  validateKey(key)
+  return assocMut(prev, key, putAnyMut(get(prev, key), value))
 }
 
 export function putIn(prev, path, next) {
-  validatePath(path);
-  return assocIn(prev, path, putAny(getIn(prev, path), next));
+  validatePath(path)
+  return assocIn(prev, path, putAny(getIn(prev, path), next))
 }
 
 export function putInMut(prev, path, next) {
-  validatePath(path);
-  return assocInMut(prev, path, putAnyMut(getIn(prev, path), next));
+  validatePath(path)
+  return assocInMut(prev, path, putAnyMut(getIn(prev, path), next))
 }
 
 export function putBy(prev, key, fun, ...rest) {
-  validate(fun, isFunction);
-  return put(prev, key, fun(get(prev, key), ...rest));
+  validate(fun, isFunction)
+  return put(prev, key, fun(get(prev, key), ...rest))
 }
 
 export function putByMut(prev, key, fun, ...rest) {
-  validate(fun, isFunction);
-  return putMut(prev, key, fun(get(prev, key), ...rest));
+  validate(fun, isFunction)
+  return putMut(prev, key, fun(get(prev, key), ...rest))
 }
 
 export function putInBy(prev, path, fun, ...rest) {
-  validate(fun, isFunction);
-  return putIn(prev, path, fun(getIn(prev, path), ...rest));
+  validate(fun, isFunction)
+  return putIn(prev, path, fun(getIn(prev, path), ...rest))
 }
 
 export function putInByMut(prev, path, fun, ...rest) {
-  validate(fun, isFunction);
-  return putInMut(prev, path, fun(getIn(prev, path), ...rest));
+  validate(fun, isFunction)
+  return putInMut(prev, path, fun(getIn(prev, path), ...rest))
 }
 
 export function patch(...args) {
-  if (args.length > 2) return fold1(args, patchTwo);
-  return patchTwo(...args);
+  if (args.length > 2) return fold1(args, patchTwo)
+  return patchTwo(...args)
 }
 
 export function patchMut(...args) {
-  if (args.length > 2) return fold1(args, patchTwoMut);
-  return patchTwoMut(...args);
+  if (args.length > 2) return fold1(args, patchTwoMut)
+  return patchTwoMut(...args)
 }
 
 export function merge(...args) {
-  if (args.length > 2) return fold1(args, mergeTwo);
-  return mergeTwo(...args);
+  if (args.length > 2) return fold1(args, mergeTwo)
+  return mergeTwo(...args)
 }
 
 export function mergeMut(...args) {
-  if (args.length > 2) return fold1(args, mergeTwoMut);
-  return mergeTwoMut(...args);
+  if (args.length > 2) return fold1(args, mergeTwoMut)
+  return mergeTwoMut(...args)
 }
 
 export function insert(list, index, value) {
-  list = onlyArray(list);
-  validateBounds(list, index);
-  list = list.slice();
-  list.splice(index, 0, value);
-  return list;
+  list = onlyArray(list)
+  validateBounds(list, index)
+  list = list.slice()
+  list.splice(index, 0, value)
+  return list
 }
 
 export function insertMut(list, index, value) {
-  list = onlyArray(list);
-  validateBounds(list, index);
-  list.splice(index, 0, value);
-  return list;
+  list = onlyArray(list)
+  validateBounds(list, index)
+  list.splice(index, 0, value)
+  return list
 }
 
 export function remove(value, key) {
   if (isArray(value)) {
-    validate(key, isInteger);
-    return listRemove(value, key);
+    validate(key, isInteger)
+    return listRemove(value, key)
   }
-  validateKey(key);
-  return dictRemove(onlyDict(value), key);
+  validateKey(key)
+  return dictRemove(onlyDict(value), key)
 }
 
 export function removeMut(value, key) {
   if (isArray(value)) {
-    validate(key, isInteger);
-    return listRemoveMut(value, key);
+    validate(key, isInteger)
+    return listRemoveMut(value, key)
   }
-  validateKey(key);
-  return dictRemoveMut(onlyDict(value), key);
+  validateKey(key)
+  return dictRemoveMut(onlyDict(value), key)
 }
 
 // Too much logic, support code, and overhead. TODO simplify.
 export function removeIn(value, path) {
-  validatePath(path);
-  if (!path.length) return undefined;
+  validatePath(path)
+  if (!path.length) return undefined
 
-  value = onlyData(value);
-  if (!hasIn(value, path)) return value;
+  value = onlyData(value)
+  if (!hasIn(value, path)) return value
 
-  const prefix = init(path);
-  return assocIn(value, prefix, remove(getIn(value, prefix), last(path)));
+  const prefix = init(path)
+  return assocIn(value, prefix, remove(getIn(value, prefix), last(path)))
 }
 
 export function removeInMut(value, path) {
-  validatePath(path);
-  if (!path.length) return undefined;
+  validatePath(path)
+  if (!path.length) return undefined
 
-  value = onlyData(value);
-  if (!hasIn(value, path)) return value;
+  value = onlyData(value)
+  if (!hasIn(value, path)) return value
 
-  const prefix = init(path);
-  return assocInMut(value, prefix, removeMut(getIn(value, prefix), last(path)));
+  const prefix = init(path)
+  return assocInMut(value, prefix, removeMut(getIn(value, prefix), last(path)))
 }
 
 /* Update (internal) */
@@ -217,7 +217,7 @@ function putAny(prev, next) {
     ? isDict(next)
       ? dictReplaceBy(prev, next, putAny)
       : next
-    : next;
+    : next
 }
 
 function putAnyMut(prev, next) {
@@ -231,188 +231,188 @@ function putAnyMut(prev, next) {
     ? isDict(next)
       ? dictReplaceByMut(prev, next, putAnyMut)
       : next
-    : next;
+    : next
 }
 
 function patchTwo(prev, next) {
-  prev = onlyDict(prev);
-  next = onlyDict(next);
-  if (is(prev, next)) return prev;
-  return patchBy(prev, next, putAny);
+  prev = onlyDict(prev)
+  next = onlyDict(next)
+  if (is(prev, next)) return prev
+  return patchBy(prev, next, putAny)
 }
 
 function patchTwoMut(prev, next) {
-  prev = onlyDict(prev);
-  next = onlyDict(next);
-  if (is(prev, next)) return prev;
-  return patchByMut(prev, next, putAnyMut);
+  prev = onlyDict(prev)
+  next = onlyDict(next)
+  if (is(prev, next)) return prev
+  return patchByMut(prev, next, putAnyMut)
 }
 
 function mergeTwo(prev, next) {
-  return mergeTwoAny(onlyDict(prev), onlyDict(next));
+  return mergeTwoAny(onlyDict(prev), onlyDict(next))
 }
 
 function mergeTwoMut(prev, next) {
-  return mergeTwoAnyMut(onlyDict(prev), onlyDict(next));
+  return mergeTwoAnyMut(onlyDict(prev), onlyDict(next))
 }
 
 // Unlike `mergeTwo`, doesn't require operands to be dicts; replaces non-dicts.
 function mergeTwoAny(prev, next) {
-  if (is(prev, next)) return prev;
-  return patchBy(toDict(prev), toDict(next), mergeOrPut);
+  if (is(prev, next)) return prev
+  return patchBy(toDict(prev), toDict(next), mergeOrPut)
 }
 
 function mergeTwoAnyMut(prev, next) {
-  if (is(prev, next)) return prev;
-  return patchByMut(toDict(prev), toDict(next), mergeOrPutMut);
+  if (is(prev, next)) return prev
+  return patchByMut(toDict(prev), toDict(next), mergeOrPutMut)
 }
 
 function mergeOrPut(prev, next) {
-  return isDict(next) ? mergeTwoAny(prev, next) : putAny(prev, next);
+  return isDict(next) ? mergeTwoAny(prev, next) : putAny(prev, next)
 }
 
 function mergeOrPutMut(prev, next) {
-  return isDict(next) ? mergeTwoAnyMut(prev, next) : putAnyMut(prev, next);
+  return isDict(next) ? mergeTwoAnyMut(prev, next) : putAnyMut(prev, next)
 }
 
 function assoc(prev, key, next) {
-  if (isArray(prev)) return listPut(prev, key, next);
-  return dictPut(onlyDict(prev), key, next);
+  if (isArray(prev)) return listPut(prev, key, next)
+  return dictPut(onlyDict(prev), key, next)
 }
 
 function assocMut(prev, key, next) {
-  if (isArray(prev)) return listPutMut(prev, key, next);
-  return dictPutMut(onlyDict(prev), key, next);
+  if (isArray(prev)) return listPutMut(prev, key, next)
+  return dictPutMut(onlyDict(prev), key, next)
 }
 
 function assocIn(prev, path, next) {
-  return path.length ? assocInAt(prev, path, next, 0) : next;
+  return path.length ? assocInAt(prev, path, next, 0) : next
 }
 
 function assocInMut(prev, path, next) {
-  return path.length ? assocInAtMut(prev, path, next, 0) : next;
+  return path.length ? assocInAtMut(prev, path, next, 0) : next
 }
 
 function assocInAt(prev, path, next, index) {
-  const key = path[index];
+  const key = path[index]
   return index < path.length - 1
     ? assoc(prev, key, assocInAt(get(prev, key), path, next, index + 1))
-    : assoc(prev, key, next);
+    : assoc(prev, key, next)
 }
 
 function assocInAtMut(prev, path, next, index) {
-  const key = path[index];
+  const key = path[index]
   return index < path.length - 1
     ? assocMut(prev, key, assocInAtMut(get(prev, key), path, next, index + 1))
-    : assocMut(prev, key, next);
+    : assocMut(prev, key, next)
 }
 
 function listPut(list, index, value) {
-  validateBounds(list, index);
-  if (index < list.length && is(list[index], value)) return list;
-  const out = list.slice();
-  out[index] = value;
-  return out;
+  validateBounds(list, index)
+  if (index < list.length && is(list[index], value)) return list
+  const out = list.slice()
+  out[index] = value
+  return out
 }
 
 function listPutMut(list, index, value) {
-  validateBounds(list, index);
-  if (index < list.length && is(list[index], value)) return list;
-  list[index] = value;
-  return list;
+  validateBounds(list, index)
+  if (index < list.length && is(list[index], value)) return list
+  list[index] = value
+  return list
 }
 
 function dictPut(dict, key, value) {
-  key = String(key);
-  if (has(dict, key) && is(dict[key], value)) return dict;
-  const out = {};
-  assign(out, dict);
-  out[key] = value;
-  return out;
+  key = String(key)
+  if (has(dict, key) && is(dict[key], value)) return dict
+  const out = {}
+  assign(out, dict)
+  out[key] = value
+  return out
 }
 
 function dictPutMut(dict, key, value) {
-  key = String(key);
-  if (has(dict, key) && is(dict[key], value)) return dict;
-  dict[key] = value;
-  return dict;
+  key = String(key)
+  if (has(dict, key) && is(dict[key], value)) return dict
+  dict[key] = value
+  return dict
 }
 
 function listRemove(list, index) {
   if (isNatural(index) && index < list.length) {
-    list = list.slice();
-    list.splice(index, 1);
+    list = list.slice()
+    list.splice(index, 1)
   }
-  return list;
+  return list
 }
 
 function listRemoveMut(list, index) {
   if (isNatural(index) && index < list.length) {
-    list.splice(index, 1);
+    list.splice(index, 1)
   }
-  return list;
+  return list
 }
 
 function dictRemove(dict, key) {
-  key = String(key);
-  if (!has(dict, key)) return dict;
-  const out = {};
+  key = String(key)
+  if (!has(dict, key)) return dict
+  const out = {}
   for (const dkey in dict) {
-    if (dkey === key) continue;
-    out[dkey] = dict[dkey];
+    if (dkey === key) continue
+    out[dkey] = dict[dkey]
   }
-  return equalBy(dict, out, is) ? dict : out;
+  return equalBy(dict, out, is) ? dict : out
 }
 
 function dictRemoveMut(dict, key) {
-  key = String(key);
-  if (!has(dict, key)) return dict;
-  delete dict[key];
-  return dict;
+  key = String(key)
+  if (!has(dict, key)) return dict
+  delete dict[key]
+  return dict
 }
 
 function listReplaceBy(prev, next, fun) {
-  const out = Array_(next.length);
-  for (let i = 0; i < next.length; i += 1) out[i] = fun(prev[i], next[i]);
-  return equalBy(prev, out, is) ? prev : out;
+  const out = Array_(next.length)
+  for (let i = 0; i < next.length; i += 1) out[i] = fun(prev[i], next[i])
+  return equalBy(prev, out, is) ? prev : out
 }
 
 function listReplaceByMut(prev, next, fun) {
   for (let i = 0; i < next.length; i += 1) {
-    assignIfChanged(prev, i, fun(prev[i], next[i]));
+    assignIfChanged(prev, i, fun(prev[i], next[i]))
   }
   if (next.length < prev.length) {
-    prev.splice(next.length, prev.length - next.length);
+    prev.splice(next.length, prev.length - next.length)
   }
-  return prev;
+  return prev
 }
 
 function dictReplaceBy(prev, next, fun) {
-  const out = {};
-  for (const key in next) out[key] = fun(prev[key], next[key]);
-  return equalBy(prev, out, is) ? prev : out;
+  const out = {}
+  for (const key in next) out[key] = fun(prev[key], next[key])
+  return equalBy(prev, out, is) ? prev : out
 }
 
 function dictReplaceByMut(prev, next, fun) {
   for (const key in next) {
-    assignIfChanged(prev, key, fun(prev[key], next[key]));
+    assignIfChanged(prev, key, fun(prev[key], next[key]))
   }
-  for (const key in prev) if (!has(next, key)) delete prev[key];
-  return prev;
+  for (const key in prev) if (!has(next, key)) delete prev[key]
+  return prev
 }
 
 function patchBy(prev, next, fun) {
-  const out = {};
-  assign(out, prev);
-  for (const key in next) out[key] = fun(prev[key], next[key]);
-  return equalBy(prev, out, is) ? prev : out;
+  const out = {}
+  assign(out, prev)
+  for (const key in next) out[key] = fun(prev[key], next[key])
+  return equalBy(prev, out, is) ? prev : out
 }
 
 function patchByMut(prev, next, fun) {
   for (const key in next) {
-    assignIfChanged(prev, key, fun(prev[key], next[key]));
+    assignIfChanged(prev, key, fun(prev[key], next[key]))
   }
-  return prev;
+  return prev
 }
 
 /* Utils */
@@ -420,174 +420,174 @@ function patchByMut(prev, next, fun) {
 // Avoid reassignment of same value, for immer's sake
 function assignIfChanged(prev, key, nextVal) {
   if (!is(prev[key], nextVal)) {
-    prev[key] = nextVal;
+    prev[key] = nextVal
   }
-  return prev;
+  return prev
 }
 
 function validatePath(value) {
-  validate(value, isArray);
-  value.forEach(validateKey);
+  validate(value, isArray)
+  value.forEach(validateKey)
 }
 
 function validateKey(value) {
   // The readme explains why we do this.
-  if (isSymbol(value)) throw Error(`unexpected symbol key ${show(value)}`);
-  validate(value, isViableAsKey);
+  if (isSymbol(value)) throw Error(`unexpected symbol key ${show(value)}`)
+  validate(value, isViableAsKey)
 }
 
 // Note that when accessing a dict property, a number is converted to a string.
 function isViableAsKey(value) {
-  return isString(value) || isFinite(value);
+  return isString(value) || isFinite(value)
 }
 
 function isNumber(value) {
-  return typeof value === "number";
+  return typeof value === 'number'
 }
 
 function isFinite(value) {
-  return isNumber(value) && !isNaN(value) && !isInfinity(value);
+  return isNumber(value) && !isNaN(value) && !isInfinity(value)
 }
 
 function isNaN(value) {
-  return value !== value; // eslint-disable-line no-self-compare
+  return value !== value // eslint-disable-line no-self-compare
 }
 
 function isInfinity(value) {
-  return value === Infinity || value === -Infinity;
+  return value === Infinity || value === -Infinity
 }
 
 function isObject(value) {
-  return value !== null && typeof value === "object";
+  return value !== null && typeof value === 'object'
 }
 
 function isDict(value) {
-  if (!isObject(value)) return false;
-  const proto = Object_.getPrototypeOf(value);
-  return proto === null || proto === NOP;
+  if (!isObject(value)) return false
+  const proto = Object_.getPrototypeOf(value)
+  return proto === null || proto === NOP
 }
 
 function isArray(value) {
-  return isObject(value) && value instanceof Array_;
+  return isObject(value) && value instanceof Array_
 }
 
 function isFunction(value) {
-  return typeof value === "function";
+  return typeof value === 'function'
 }
 
 function isInteger(value) {
-  return typeof value === "number" && value % 1 === 0;
+  return typeof value === 'number' && value % 1 === 0
 }
 
 function isNatural(value) {
-  return isInteger(value) && value >= 0;
+  return isInteger(value) && value >= 0
 }
 
 function isString(value) {
-  return typeof value === "string";
+  return typeof value === 'string'
 }
 
 function isSymbol(value) {
-  return typeof value === "symbol";
+  return typeof value === 'symbol'
 }
 
 function everyListPairBy(one, other, fun) {
-  if (one.length !== other.length) return false;
+  if (one.length !== other.length) return false
   for (let i = 0; i < one.length; i += 1) {
-    if (!fun(one[i], other[i])) return false;
+    if (!fun(one[i], other[i])) return false
   }
-  return true;
+  return true
 }
 
 function everyDictPairBy(one, other, fun) {
   // Breadth-first: compare key sets.
-  for (const key in one) if (!has(other, key)) return false;
-  for (const key in other) if (!has(one, key)) return false;
+  for (const key in one) if (!has(other, key)) return false
+  for (const key in other) if (!has(one, key)) return false
 
   // Now a depth-first comparison.
-  for (const key in one) if (!fun(one[key], other[key])) return false;
-  return true;
+  for (const key in one) if (!fun(one[key], other[key])) return false
+  return true
 }
 
 function fold(list, acc, fun, ...rest) {
   for (let i = 0; i < list.length; i += 1) {
-    acc = fun(acc, list[i], i, ...rest);
+    acc = fun(acc, list[i], i, ...rest)
   }
-  return acc;
+  return acc
 }
 
 function fold1(list, fun, ...rest) {
-  let [acc] = list;
+  let [acc] = list
   for (let i = 1; i < list.length; i += 1) {
-    acc = fun(acc, list[i], i, ...rest);
+    acc = fun(acc, list[i], i, ...rest)
   }
-  return acc;
+  return acc
 }
 
 // Requires extreme care: when calling this on a dict, a numeric key must be
 // converted to a string first.
 function has(value, key) {
-  return isObject(value) && NOP.hasOwnProperty.call(value, key);
+  return isObject(value) && NOP.hasOwnProperty.call(value, key)
 }
 
 // Suspicious. Would prefer to get rid of this.
 function hasIn(value, path) {
-  return fold(path, value, getOrMissing) !== missing;
+  return fold(path, value, getOrMissing) !== missing
 }
 
-const missing = Symbol("missing");
+const missing = Symbol('missing')
 
 function getOrMissing(value, key) {
-  key = String(key);
-  return has(value, key) ? value[key] : missing;
+  key = String(key)
+  return has(value, key) ? value[key] : missing
 }
 
 function assign(out, src) {
-  for (const key in src) out[key] = src[key];
+  for (const key in src) out[key] = src[key]
 }
 
 function onlyData(value) {
-  return isArray(value) ? value : onlyDict(value);
+  return isArray(value) ? value : onlyDict(value)
 }
 
 function onlyArray(value) {
-  if (isNil(value)) return [];
-  validate(value, isArray);
-  return value;
+  if (isNil(value)) return []
+  validate(value, isArray)
+  return value
 }
 
 function onlyDict(value) {
-  if (isNil(value)) return {};
-  validate(value, isDict);
-  return value;
+  if (isNil(value)) return {}
+  validate(value, isDict)
+  return value
 }
 
 function toDict(value) {
-  return isDict(value) ? value : {};
+  return isDict(value) ? value : {}
 }
 
 function isNil(value) {
-  return value == null;
+  return value == null
 }
 
 function init(list) {
-  return list.slice(0, list.length - 1);
+  return list.slice(0, list.length - 1)
 }
 
 function last(list) {
-  return list[list.length - 1];
+  return list[list.length - 1]
 }
 
 function validateBounds(list, index) {
-  validate(index, isNatural);
+  validate(index, isNatural)
   if (!(index <= list.length)) {
-    throw Error(`index ${index} out of bounds for length ${list.length}`);
+    throw Error(`index ${index} out of bounds for length ${list.length}`)
   }
 }
 
 function validate(value, test) {
   if (!test(value)) {
-    throw Error(`expected ${show(value)} to satisfy test ${show(test)}`);
+    throw Error(`expected ${show(value)} to satisfy test ${show(test)}`)
   }
 }
 
@@ -598,5 +598,5 @@ function show(value) {
     ? JSON.stringify(value)
     : isString(value)
     ? `"${value}"`
-    : String(value);
+    : String(value)
 }


### PR DESCRIPTION
@mitranim I wanted to run this idea by you before I invest the time to clean this up.

I have a use case where I'm using [immer](https://immerjs.github.io/immer) to produce `patches` for changes made to a large dictionary. Immer works by using a proxy to track all changes made to an object. In my case, the modified data comes as a json payload from an API, so I'm applying it as one big change. Using common `merge` functions (including yours) results in immer reporting more deltas than expected. This is because the algorithm creates a new object when any of its properties changed (rather than modifying it in place).

While looking for a solution, I came across this library. I was impressed by how concise and readable the code base is, and decided that it would be very easy to modify it to suit my needs. An hour or so later, this PR is the result. It works exactly how I need it to.

The only difference is that, for each of the functions, the first input is modified in place, rather than creating a new one. The same structural sharing principles are used, and only the minimal necessary modifications are made.

So the question is, would you like to merge this functionality into emerge, or should I make it a complete fork?

If you would like to merge it here, then we should discuss _how_.

1. I don't particularly like the names that I picked, open to alternatives.
2. Might be better to put them in a sub-module? `import { merge } from 'emerge/mutable'`
3. Sorry for the extra noise caused by autoformatting by prettier. Do you want to use prettier, or should I fix the styling to match?

